### PR TITLE
Update illuminate support version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^7.3",
-        "illuminate/support": "8.*"
+        "illuminate/support": "^8.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^7.3",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0|^9.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^7.3",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^7.3",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/support": "^8.0|^9.0|^10.0"
     },
     "authors": [
         {


### PR DESCRIPTION
This is to make it compatible with the shift/upgrades to 1p-points.